### PR TITLE
Connect logger to Notion logger

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,22 @@
+import * as dotenv from 'dotenv'
+import { Client, LogLevel as NotionLogLevel } from '@notionhq/client/build/src'
+import { pino } from 'pino'
+
+dotenv.config()
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+const logLevel: LogLevel = (process.env.LOG_LEVEL ?? 'info') as LogLevel
+
+export const logger = pino({ level: logLevel })
+
+const notionLoggerAdapter = (
+  logLevel: NotionLogLevel,
+  message: string,
+  extraInfo: Record<string, unknown>
+): void => logger[logLevel as LogLevel](extraInfo, message)
+
+export const notion = new Client({
+  auth: process.env.NOTION_KEY,
+  logLevel: logLevel as NotionLogLevel,
+  logger: notionLoggerAdapter
+})

--- a/src/helpers/notion_demo.ts
+++ b/src/helpers/notion_demo.ts
@@ -1,7 +1,6 @@
-import { Client } from '@notionhq/client/build/src'
+import { notion } from '../config'
 import { CreatePageResponse } from '@notionhq/client/build/src/api-endpoints'
 
-const notion = new Client({ auth: process.env.NOTION_KEY })
 const databaseId = process.env.NOTION_DATABASE_ID ?? ''
 
 async function addItem (text: string): Promise<CreatePageResponse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
-import * as dotenv from 'dotenv'
-import { pino } from 'pino'
 
+import { logger } from './config'
 import addItem from './helpers/notion_demo'
-
-dotenv.config()
-const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' })
-logger.info('started server')
 
 // FIXME: this is purely here to boost code-coverage.
 export const callAddItem = async function (): Promise<void> {


### PR DESCRIPTION
This PR adds an adapter from the `pino` logger to the Notion `Client` logger.